### PR TITLE
Add set_all_child_leafs() to FunctionsCompressedNodes

### DIFF
--- a/mra/madness/include/functionnode.h
+++ b/mra/madness/include/functionnode.h
@@ -332,6 +332,14 @@ namespace mra {
           return m_is_child_leafs[i][child];
         }
 
+        void set_all_child_leafs() {
+          for (auto& node : m_is_child_leafs) {
+            for (auto& c : node) {
+              c = true;
+            }
+          }
+        }
+
         auto& coeffs() {
           return m_coeffs;
         }


### PR DESCRIPTION
Needed to balance gaxpy on compressed nodes.