### PR TITLE
Fixes for changes in how ttg::Buffer takes pointers

### DIFF
--- a/cmake/modules/FindOrFetchTTG.cmake
+++ b/cmake/modules/FindOrFetchTTG.cmake
@@ -9,8 +9,8 @@ else (TARGET ttg)
 include(FetchContent)
 FetchContent_Declare(
       ttg
-      GIT_REPOSITORY      https://github.com/TESSEOrg/ttg.git
-      GIT_TAG             26172b095ae1fdbb1299086da4193561b41a89f1
+      GIT_REPOSITORY      https://github.com/devreal/ttg.git
+      GIT_TAG             914cc3d75385e129b3a2b3d910a41501300b5a47
   )
 
 #FetchContent_Declare(

--- a/mra/madness/include/gaussian.h
+++ b/mra/madness/include/gaussian.h
@@ -16,10 +16,10 @@ namespace mra {
     // Test gaussian functor
     template <typename T, Dimension NDIM>
     class Gaussian {
-        const T expnt;
-        const Coordinate<T,NDIM> origin;
-        const T fac;
-        const T maxr;
+        T expnt;
+        Coordinate<T,NDIM> origin;
+        T fac;
+        T maxr;
         Level initlev;
     public:
         /* default construction required for ttg::Buffer */
@@ -46,7 +46,9 @@ namespace mra {
 
         /* default copy ctor and operator */
         Gaussian(const Gaussian&) = default;
+        Gaussian(Gaussian&&) = default;
         Gaussian& operator=(const Gaussian&) = default;
+        Gaussian& operator=(Gaussian&&) = default;
 
         // T operator()(const Coordinate<T,NDIM>& r) const {
         //     T rsq = 0.0;

--- a/mra/madness/include/gl.h
+++ b/mra/madness/include/gl.h
@@ -15,6 +15,10 @@ namespace mra {
     /// Arrays for points and weights for the Gauss-Legendre quadrature on [0,1].
     /// only available directly on the host
     extern const double gl_data[128][64];
+
+    struct empty_deleter {
+      void operator()(const double*) const {}
+    };
   } // namespace detail
 
   /**
@@ -23,7 +27,7 @@ namespace mra {
 
   template<typename T>
   inline ttg::Buffer<const T> GLbuffer() {
-    return ttg::Buffer<const T>(&detail::gl_data[0][0], sizeof(detail::gl_data)/sizeof(T));
+    return ttg::Buffer<const T>(std::unique_ptr<const T[], detail::empty_deleter>(&detail::gl_data[0][0]), sizeof(detail::gl_data)/sizeof(T));
   }
 
   template<typename T>


### PR DESCRIPTION
All pointers must now be managed so that they don't disappear silently. This needs some adjustment in how we allocate the Domain and gaussian arrays.

In preparation for https://github.com/TESSEorg/ttg/pull/301