### PR TITLE
Increase number of threads per block

### DIFF
--- a/mra/madness/include/kernels/compress.h
+++ b/mra/madness/include/kernels/compress.h
@@ -56,7 +56,7 @@ namespace mra {
     }
 
     template<typename T, Dimension NDIM>
-    LAUNCH_BOUNDS(MRA_MAX_K*MRA_MAX_K)
+    LAUNCH_BOUNDS(max_threads(2*MRA_MAX_K))
     GLOBALSCOPE void compress_kernel(
       Key<NDIM> key,
       size_type N,
@@ -112,8 +112,7 @@ namespace mra {
     const std::array<TensorView<T, NDIM+1>, Key<NDIM>::num_children()>& in_views,
     ttg::device::Stream stream)
   {
-    size_type max_threads = std::min(K, MRA_MAX_K_SIZET);
-    Dim3 thread_dims = Dim3(max_threads, max_threads, 1);
+    Dim3 thread_dims = max_thread_dims(2*K);
     size_type numthreads = thread_dims.x*thread_dims.y*thread_dims.z;
 
     CALL_KERNEL(detail::compress_kernel, N, thread_dims, numthreads*sizeof(T), stream,

--- a/mra/madness/include/kernels/fcoeffs.h
+++ b/mra/madness/include/kernels/fcoeffs.h
@@ -99,7 +99,7 @@ namespace mra {
 
     template<typename Fn, typename T, Dimension NDIM>
     GLOBALSCOPE void
-    LAUNCH_BOUNDS(MRA_MAX_K*MRA_MAX_K)
+    LAUNCH_BOUNDS(max_threads(MRA_MAX_K))
     fcoeffs_kernel(
       const Domain<NDIM>& D,
       const T* gldata,
@@ -166,12 +166,11 @@ namespace mra {
       ttg::device::Stream stream)
   {
     /**
-     * Launch the kernel with KxK threads in each of the N blocks.
+     * Launch the kernel with KxKxK threads in each of the N blocks.
      * Computation on functions is embarassingly parallel and no
      * synchronization is required.
      */
-    size_type max_threads = std::min(K, MRA_MAX_K_SIZET);
-    Dim3 thread_dims = Dim3(max_threads, max_threads, 1);
+    Dim3 thread_dims = max_thread_dims(K);
     size_type numthreads = thread_dims.x*thread_dims.y*thread_dims.z;
 
     /* launch one block per child */

--- a/mra/madness/include/kernels/gaxpy.h
+++ b/mra/madness/include/kernels/gaxpy.h
@@ -23,6 +23,7 @@ namespace mra {
     }
 
     template <typename T, Dimension NDIM>
+    LAUNCH_BOUNDS(max_threads(2*MRA_MAX_K))
     GLOBALSCOPE void gaxpy_kernel(
       const TensorView<T, NDIM+1> nodeA_view,
       const TensorView<T, NDIM+1> nodeB_view,
@@ -58,8 +59,7 @@ namespace mra {
     size_type K,
     ttg::device::Stream stream)
   {
-    size_type max_threads = std::min(2*K, 2*MRA_MAX_K_SIZET);
-    Dim3 thread_dims = Dim3(max_threads, max_threads, 1);
+    Dim3 thread_dims = max_thread_dims(2*K);
 
     CALL_KERNEL(detail::gaxpy_kernel, N, thread_dims, 0, stream,
       (funcA, funcB, funcR, scalarA, scalarB, N, key));

--- a/mra/madness/include/kernels/multiply.h
+++ b/mra/madness/include/kernels/multiply.h
@@ -47,7 +47,7 @@ namespace mra {
 
     template <typename T, Dimension NDIM>
     GLOBALSCOPE void
-    LAUNCH_BOUNDS(MRA_MAX_K*MRA_MAX_K)
+    LAUNCH_BOUNDS(max_threads(MRA_MAX_K))
     multiply_kernel(
       const Domain<NDIM>& D,
       const TensorView<T, NDIM+1> nodeA_view,
@@ -99,8 +99,7 @@ namespace mra {
     T* tmp,
     ttg::device::Stream stream)
   {
-    size_type max_threads = std::min(K, MRA_MAX_K_SIZET);
-    Dim3 thread_dims = Dim3(max_threads, max_threads, 1);
+    Dim3 thread_dims = max_thread_dims(2*K);
 
     CALL_KERNEL(detail::multiply_kernel, N, thread_dims, 0, stream,
       (D, funcA, funcB, funcR, tmp,

--- a/mra/madness/include/kernels/norm.h
+++ b/mra/madness/include/kernels/norm.h
@@ -28,6 +28,7 @@ namespace mra {
     }
 
     template <typename T, Dimension NDIM>
+    LAUNCH_BOUNDS(max_threads(2*MRA_MAX_K))
     GLOBALSCOPE void norm_kernel(
       const TensorView<T, NDIM+1> node,
       T* result_norms,
@@ -64,7 +65,7 @@ namespace mra {
     std::array<const T*, Key<NDIM>::num_children()>& child_norms,
     ttg::device::Stream stream)
   {
-    Dim3 thread_dims = Dim3(K, K, 1);
+    Dim3 thread_dims = max_thread_dims(2*K);
     size_type numthreads = thread_dims.x*thread_dims.y*thread_dims.z;
 
     CALL_KERNEL(detail::norm_kernel, N, thread_dims, numthreads*sizeof(T), stream,

--- a/mra/madness/include/kernels/reconstruct.h
+++ b/mra/madness/include/kernels/reconstruct.h
@@ -57,7 +57,7 @@ namespace mra {
 
     template<typename T, Dimension NDIM>
     GLOBALSCOPE void
-    LAUNCH_BOUNDS(MRA_MAX_K*MRA_MAX_K)
+    LAUNCH_BOUNDS(max_threads(2*MRA_MAX_K))
     reconstruct_kernel(
       Key<NDIM> key,
       size_type N,
@@ -111,8 +111,7 @@ namespace mra {
     T* tmp,
     ttg::device::Stream stream)
   {
-    size_type max_threads = std::min(K, MRA_MAX_K_SIZET);
-    Dim3 thread_dims = Dim3(max_threads, max_threads, 1);
+    Dim3 thread_dims = max_thread_dims(2*K);
     CALL_KERNEL(detail::reconstruct_kernel, N, thread_dims, 0, stream,
       (key, N, K, node, tmp, hg, from_parent, r_arr));
     checkSubmit();

--- a/mra/madness/include/kernels/transform.h
+++ b/mra/madness/include/kernels/transform.h
@@ -9,27 +9,27 @@
 
 namespace mra {
 
-/* reference implementation, adapted from madness */
 template <typename aT, typename bT, typename cT>
 SCOPE
 void mTxmq(size_type dimi, size_type dimj, size_type dimk,
            cT* __restrict__ c, const aT* a, const bT* b, std::ptrdiff_t ldb=-1) {
   if (ldb == -1) ldb=dimj;
-  /* trivial 2D implementation for devices */
-  if (threadIdx.z == 0) {
-    for (size_type i = threadIdx.y; i < dimi; i += blockDim.y) {
-      cT* ci = c + i*dimj; // the row of C all threads in dim x work on
-      const aT *aik_ptr = a + i;
-      // beta = 0
-      for (size_type j = threadIdx.x; j < dimj; j += blockDim.x) {
-        ci[j] = 0.0;
-      }
+  /* 3D implementation utilizing the tall-and-skinny shape of a(i,k) and c(i,j) (see transform() below).
+   * We distribute work along the i-dimension across the Y and Z dimensions of the thread-block.
+   * The X dimension of the thread-block computes along the j dimension. The k dimension is not parallelized
+   * as it would require reductions (could be added later for square matrices). */
+  for (size_type i = threadIdx.z*blockDim.y+threadIdx.y; i < dimi; i += blockDim.z*blockDim.y) {
+    cT* ci = c + i*dimj; // the row of C all threads in dim x work on
+    const aT *aik_ptr = a + i;
+    // beta = 0
+    for (size_type j = threadIdx.x; j < dimj; j += blockDim.x) {
+      ci[j] = 0.0;
+    }
 
-      for (long k=0; k<dimk; ++k,aik_ptr+=dimi) { /* not parallelized */
-        aT aki = *aik_ptr;
-        for (size_type j = threadIdx.x; j < dimj; j += blockDim.x) {
-          ci[j] += aki*b[k*ldb+j];
-        }
+    for (long k=0; k<dimk; ++k,aik_ptr+=dimi) { /* not parallelized */
+      aT aki = *aik_ptr;
+      for (size_type j = threadIdx.x; j < dimj; j += blockDim.x) {
+        ci[j] += aki*b[k*ldb+j];
       }
     }
   }


### PR DESCRIPTION
We can run with up to KxKxmin(K,1024/K**2) threads in each block. This is straigh-forward for assignments (via the flat iteration space) and for reductions.
For the tall-and-skinny (100x10 or (400x20) matrices in transform we can distribute the i-dimension across both the y and z dimension of the thread-block.

Overall, this increases the concurrency within each block and leads to significant speedups (about 2x on an A100).