### PR TITLE
Map SCOPE to inline on the host and clean up `SCOPE inline`

### DIFF
--- a/include/mra/misc/hash.h
+++ b/include/mra/misc/hash.h
@@ -7,13 +7,13 @@
 namespace mra {
 
     namespace detail {
-        SCOPE static inline uint64_t rot(uint64_t x)
+        SCOPE uint64_t rot(uint64_t x)
         {
             constexpr const uint64_t n = 27;
             return (x<<n) | (x>>(64-n));
         }
 
-        SCOPE static inline uint32_t rot(uint32_t x)
+        SCOPE uint32_t rot(uint32_t x)
         {
             constexpr const uint32_t n = 13;
             return (x<<n) | (x>>(32-n));
@@ -45,13 +45,13 @@ namespace mra {
     }
 
     /// Multiplicative hash with rotation to mix bits (std::hash does not) - empirically good enuf for keys
-    SCOPE static inline uint64_t mulhash(uint64_t hash, Translation data) {
+    SCOPE uint64_t mulhash(uint64_t hash, Translation data) {
         constexpr const uint64_t m = 11400714819323198393ul;
         return detail::rot(hash)^(data*m);
     }
 
     /// Multiplicative hash with rotation to mix bits (std::hash does not) - empirically good enuf for keys
-    SCOPE static inline uint32_t mulhash(uint32_t hash, Translation data) {
+    SCOPE uint32_t mulhash(uint32_t hash, Translation data) {
         constexpr const uint32_t m = 2654435761u;
         return detail::rot(hash)^(data*m);
     }

--- a/include/mra/misc/key.h
+++ b/include/mra/misc/key.h
@@ -9,10 +9,10 @@
 namespace mra {
 
     /// Extracts the n'th bit as 0 or 1
-    inline static Translation get_bit(int bits, Dimension n) {return ((bits>>n) & 0x1ul);}
+    SCOPE Translation get_bit(int bits, Dimension n) {return ((bits>>n) & 0x1ul);}
 
     /// Extracts the low bit as 0 or 1
-    inline static Translation low_bit(Translation l) {return l & Translation(1);}
+    SCOPE Translation low_bit(Translation l) {return l & Translation(1);}
 
     template <Dimension NDIM>
     class Key {
@@ -186,65 +186,65 @@ namespace mra {
             return n != -1;
         }
     };
-    template <> inline SCOPE Key<1> Key<1>::parent(Level generation) const {
+    template <> SCOPE Key<1> Key<1>::parent(Level generation) const {
         generation = std::min(generation,n);
         return Key<1>(n-generation,{l[0]>>generation});
     }
 
-    template <> inline SCOPE Key<2> Key<2>::parent(Level generation) const {
+    template <> SCOPE Key<2> Key<2>::parent(Level generation) const {
         generation = std::min(generation,n);
         return Key<2>(n-generation,{l[0]>>generation,l[1]>>generation});
     }
 
-    template <> inline SCOPE Key<3> Key<3>::parent(Level generation) const {
+    template <> SCOPE Key<3> Key<3>::parent(Level generation) const {
         generation = std::min(generation,n);
         return Key<3>(n-generation,{l[0]>>generation,l[1]>>generation,l[2]>>generation});
     }
 
-    template <> inline SCOPE Key<1> Key<1>::first_child() const {
+    template <> SCOPE Key<1> Key<1>::first_child() const {
         assert(n<MAX_LEVEL);
         return Key<1>(n+1, {l[0]<<1});
     }
 
-    template <> inline SCOPE Key<2> Key<2>::first_child() const {
+    template <> SCOPE Key<2> Key<2>::first_child() const {
         assert(n<MAX_LEVEL);
         return Key<2>(n+1, {l[0]<<1,l[1]<<1});
     }
 
-    template <> inline SCOPE Key<3> Key<3>::first_child() const {
+    template <> SCOPE Key<3> Key<3>::first_child() const {
         assert(n<MAX_LEVEL);
         return Key<3>(n+1, {l[0]<<1,l[1]<<1,l[2]<<1});
     }
 
-    template <> inline SCOPE Key<1> Key<1>::last_child() const {
+    template <> SCOPE Key<1> Key<1>::last_child() const {
         assert(n<MAX_LEVEL);
         return Key<1>(n+1, {(l[0]<<1)+1});
     }
 
-    template <> inline SCOPE Key<2> Key<2>::last_child() const {
+    template <> SCOPE Key<2> Key<2>::last_child() const {
         assert(n<MAX_LEVEL);
         return Key<2>(n+1, {(l[0]<<1)+1,(l[1]<<1)+1});
 
     }
 
-    template <> inline SCOPE Key<3> Key<3>::last_child() const {
+    template <> SCOPE Key<3> Key<3>::last_child() const {
         assert(n<MAX_LEVEL);
         return Key<3>(n+1, {(l[0]<<1)+1,(l[1]<<1)+1,(l[2]<<1)+1});
     }
 
-    template <> inline SCOPE void Key<1>::next_child(int& bits) {
+    template <> SCOPE void Key<1>::next_child(int& bits) {
         bits++; l[0]++;
         rehash();
     }
 
-    template <> inline SCOPE void Key<2>::next_child(int& bits) {
+    template <> SCOPE void Key<2>::next_child(int& bits) {
         int oldbits = bits++;
         l[0] +=  (bits&0x1)     -  (oldbits&0x1);
         l[1] += ((bits&0x2)>>1) - ((oldbits&0x2)>>1);
         rehash();
     }
 
-    template <> inline SCOPE void Key<3>::next_child(int& bits) {
+    template <> SCOPE void Key<3>::next_child(int& bits) {
         int oldbits = bits++;
         l[0] +=  (bits&0x1)     -  (oldbits&0x1);
         l[1] += ((bits&0x2)>>1) - ((oldbits&0x2)>>1);
@@ -252,15 +252,15 @@ namespace mra {
         rehash();
     }
 
-    template <> inline SCOPE int Key<1>::childindex() const {
+    template <> SCOPE int Key<1>::childindex() const {
         return l[0]&0x1;
     }
 
-    template <> inline SCOPE int Key<2>::childindex() const {
+    template <> SCOPE int Key<2>::childindex() const {
         return ((l[1]&0x1)<<1) | (l[0]&0x1);
     }
 
-    template <> inline SCOPE int Key<3>::childindex() const {
+    template <> SCOPE int Key<3>::childindex() const {
         return ((l[2]&0x1)<<2)  | ((l[1]&0x1)<<1) | (l[0]&0x1);
     }
 

--- a/include/mra/misc/key.h
+++ b/include/mra/misc/key.h
@@ -54,7 +54,7 @@ namespace mra {
         /// Move assignment default is OK
         SCOPE Key& operator=(Key<NDIM>&& key) = default;
 
-        auto operator<=>(const Key<NDIM>&) const = default;
+        SCOPE auto operator<=>(const Key<NDIM>&) const = default;
 
         /// Hash to unsigned value
         SCOPE HashValue hash() const {return rehash();}
@@ -186,83 +186,6 @@ namespace mra {
             return n != -1;
         }
     };
-    template <> SCOPE Key<1> Key<1>::parent(Level generation) const {
-        generation = std::min(generation,n);
-        return Key<1>(n-generation,{l[0]>>generation});
-    }
-
-    template <> SCOPE Key<2> Key<2>::parent(Level generation) const {
-        generation = std::min(generation,n);
-        return Key<2>(n-generation,{l[0]>>generation,l[1]>>generation});
-    }
-
-    template <> SCOPE Key<3> Key<3>::parent(Level generation) const {
-        generation = std::min(generation,n);
-        return Key<3>(n-generation,{l[0]>>generation,l[1]>>generation,l[2]>>generation});
-    }
-
-    template <> SCOPE Key<1> Key<1>::first_child() const {
-        assert(n<MAX_LEVEL);
-        return Key<1>(n+1, {l[0]<<1});
-    }
-
-    template <> SCOPE Key<2> Key<2>::first_child() const {
-        assert(n<MAX_LEVEL);
-        return Key<2>(n+1, {l[0]<<1,l[1]<<1});
-    }
-
-    template <> SCOPE Key<3> Key<3>::first_child() const {
-        assert(n<MAX_LEVEL);
-        return Key<3>(n+1, {l[0]<<1,l[1]<<1,l[2]<<1});
-    }
-
-    template <> SCOPE Key<1> Key<1>::last_child() const {
-        assert(n<MAX_LEVEL);
-        return Key<1>(n+1, {(l[0]<<1)+1});
-    }
-
-    template <> SCOPE Key<2> Key<2>::last_child() const {
-        assert(n<MAX_LEVEL);
-        return Key<2>(n+1, {(l[0]<<1)+1,(l[1]<<1)+1});
-
-    }
-
-    template <> SCOPE Key<3> Key<3>::last_child() const {
-        assert(n<MAX_LEVEL);
-        return Key<3>(n+1, {(l[0]<<1)+1,(l[1]<<1)+1,(l[2]<<1)+1});
-    }
-
-    template <> SCOPE void Key<1>::next_child(int& bits) {
-        bits++; l[0]++;
-        rehash();
-    }
-
-    template <> SCOPE void Key<2>::next_child(int& bits) {
-        int oldbits = bits++;
-        l[0] +=  (bits&0x1)     -  (oldbits&0x1);
-        l[1] += ((bits&0x2)>>1) - ((oldbits&0x2)>>1);
-        rehash();
-    }
-
-    template <> SCOPE void Key<3>::next_child(int& bits) {
-        int oldbits = bits++;
-        l[0] +=  (bits&0x1)     -  (oldbits&0x1);
-        l[1] += ((bits&0x2)>>1) - ((oldbits&0x2)>>1);
-        l[2] += ((bits&0x4)>>2) - ((oldbits&0x4)>>2);
-        rehash();
-    }
-
-    template <> SCOPE int Key<1>::childindex() const {
-        return l[0]&0x1;
-    }
-
-    template <> SCOPE int Key<2>::childindex() const {
-        return ((l[1]&0x1)<<1) | (l[0]&0x1);
-    }
-
-    template <> SCOPE int Key<3>::childindex() const {
-        return ((l[2]&0x1)<<2)  | ((l[1]&0x1)<<1) | (l[0]&0x1);
-    }
 
     /// Range object used to iterate over children of a key
     template <Dimension NDIM>

--- a/include/mra/misc/platform.h
+++ b/include/mra/misc/platform.h
@@ -45,7 +45,7 @@ namespace mra::detail {
 #define LAUNCH_BOUNDS(__NT) __launch_bounds__(__NT, 2)
 #define HAVE_DEVICE_ARCH 1
 #else // __CUDA_ARCH__
-#define SCOPE
+#define SCOPE inline
 #define SYNCTHREADS() do {} while(0)
 #define DEVSCOPE inline
 #define SHARED
@@ -183,7 +183,7 @@ namespace mra {
 #endif // HAVE_DEVICE_ARCH
   }
 
-  SCOPE inline bool is_team_lead() {
+  SCOPE bool is_team_lead() {
 #if defined(HAVE_DEVICE_ARCH)
     return (0 == (threadIdx.x + threadIdx.y + threadIdx.z));
 #else  // HAVE_DEVICE_ARCH

--- a/include/mra/misc/platform.h
+++ b/include/mra/misc/platform.h
@@ -38,7 +38,7 @@ namespace mra::detail {
 #define LAUNCH_BOUNDS(__NT) __launch_bounds__(__NT, 2)
 #define HAVE_DEVICE_ARCH 1
 #elif defined(__HIP__)
-#define SCOPE __device__ __host__
+#define SCOPE __device__ __host__ inline
 #define SYNCTHREADS() __syncthreads()
 #define DEVSCOPE __device__
 #define SHARED __shared__

--- a/include/mra/misc/platform.h
+++ b/include/mra/misc/platform.h
@@ -183,7 +183,7 @@ namespace mra {
 #endif // HAVE_DEVICE_ARCH
   }
 
-  SCOPE bool is_team_lead() {
+  DEVSCOPE bool is_team_lead() {
 #if defined(HAVE_DEVICE_ARCH)
     return (0 == (threadIdx.x + threadIdx.y + threadIdx.z));
 #else  // HAVE_DEVICE_ARCH

--- a/include/mra/misc/platform.h
+++ b/include/mra/misc/platform.h
@@ -37,7 +37,7 @@ namespace mra::detail {
 #define SHARED __shared__
 #define LAUNCH_BOUNDS(__NT) __launch_bounds__(__NT, 2)
 #define HAVE_DEVICE_ARCH 1
-#elif defined(__HIP__)
+#elif defined(__HIP_DEVICE_COMPILE__)
 #define SCOPE __device__ __host__ inline
 #define SYNCTHREADS() __syncthreads()
 #define DEVSCOPE __device__
@@ -167,7 +167,7 @@ namespace mra {
  * Function returning the thread ID in a flat ID space.
  */
 namespace mra {
-  DEVSCOPE int thread_id() {
+  SCOPE int thread_id() {
 #if defined(HAVE_DEVICE_ARCH)
     return blockDim.x * ((blockDim.y * threadIdx.z) + threadIdx.y) + threadIdx.x;
 #else  // HAVE_DEVICE_ARCH
@@ -175,7 +175,7 @@ namespace mra {
 #endif // HAVE_DEVICE_ARCH
   }
 
-  DEVSCOPE int block_size() {
+  SCOPE int block_size() {
 #if defined(HAVE_DEVICE_ARCH)
     return blockDim.x * blockDim.y * blockDim.z;
 #else  // HAVE_DEVICE_ARCH
@@ -183,7 +183,7 @@ namespace mra {
 #endif // HAVE_DEVICE_ARCH
   }
 
-  DEVSCOPE bool is_team_lead() {
+  SCOPE bool is_team_lead() {
 #if defined(HAVE_DEVICE_ARCH)
     return (0 == (threadIdx.x + threadIdx.y + threadIdx.z));
 #else  // HAVE_DEVICE_ARCH

--- a/include/mra/misc/types.h
+++ b/include/mra/misc/types.h
@@ -89,19 +89,19 @@ namespace mra {
     namespace detail {
         // make_array not till c++20 ??
         template <typename T, std::size_t N, typename... Ts>
-        SCOPE static inline auto make_array_crude(const Ts&... t) {
+        SCOPE auto make_array_crude(const Ts&... t) {
             return std::array<T, N>{{t...}};
         }
 
         // will fail for zero length subtuple
         template <std::size_t Begin, std::size_t End, typename... Ts, std::size_t... I>
-        SCOPE static inline auto subtuple_to_array_of_ptrs_(std::tuple<Ts...>& t, std::index_sequence<I...>) {
+        SCOPE auto subtuple_to_array_of_ptrs_(std::tuple<Ts...>& t, std::index_sequence<I...>) {
             using arrayT = typename std::tuple_element<Begin, std::tuple<Ts*...>>::type;
             return make_array_crude<arrayT, End - Begin>(&std::get<I + Begin>(t)...);
         }
 
         template <std::size_t Begin, std::size_t End, typename... Ts, std::size_t... I>
-        SCOPE static inline auto subtuple_to_array_of_ptrs_const(const std::tuple<Ts...>& t, std::index_sequence<I...>) {
+        SCOPE auto subtuple_to_array_of_ptrs_const(const std::tuple<Ts...>& t, std::index_sequence<I...>) {
             using arrayT = typename std::tuple_element<Begin, std::tuple<const Ts*...>>::type;
             return make_array_crude<arrayT, End - Begin>(&std::get<I + Begin>(t)...);
         }
@@ -111,26 +111,26 @@ namespace mra {
 
     /// Makes an array of pointers to elements (of same type) in tuple in the open range \c [Begin,End).
     template <std::size_t Begin, std::size_t End, typename... T>
-    SCOPE static inline auto subtuple_to_array_of_ptrs(std::tuple<T...>& t) {
+    SCOPE auto subtuple_to_array_of_ptrs(std::tuple<T...>& t) {
         return detail::subtuple_to_array_of_ptrs_<Begin, End>(t, std::make_index_sequence<End - Begin>());
     }
 
     /// Makes an array of pointers to elements (of same type) in tuple in the open range \c [Begin,End).
     template <std::size_t Begin, std::size_t End, typename... T>
-    SCOPE static inline auto subtuple_to_array_of_ptrs_const(const std::tuple<T...>& t) {
+    SCOPE auto subtuple_to_array_of_ptrs_const(const std::tuple<T...>& t) {
         return detail::subtuple_to_array_of_ptrs_const<Begin, End>(t, std::make_index_sequence<End - Begin>());
     }
 
     /// Makes an array of pointers to elements (of same type) in tuple
     template <typename... T>
-    SCOPE static inline auto tuple_to_array_of_ptrs(std::tuple<T...>& t) {
+    SCOPE auto tuple_to_array_of_ptrs(std::tuple<T...>& t) {
         return detail::subtuple_to_array_of_ptrs_<0, std::tuple_size<std::tuple<T...>>::value>
             (t, std::make_index_sequence<std::tuple_size<std::tuple<T...>>::value>());
     }
 
     /// Makes an array of pointers to elements (of same type) in tuple
     template <typename... T>
-    SCOPE static inline auto tuple_to_array_of_ptrs_const(const std::tuple<T...>& t) {
+    SCOPE auto tuple_to_array_of_ptrs_const(const std::tuple<T...>& t) {
         return detail::subtuple_to_array_of_ptrs_const<0, std::tuple_size<std::tuple<T...>>::value>
             (t, std::make_index_sequence<std::tuple_size<std::tuple<T...>>::value>());
     }


### PR DESCRIPTION
The CUDA compiler warns about device functions being marked inline, so don't mark SCOPE functions as inline.

Also, some functions were not properly marked SCOPE.