### PR TITLE
Split task and kernel logic

### DIFF
--- a/include/mra/kernels/kernel_state.h
+++ b/include/mra/kernels/kernel_state.h
@@ -1,0 +1,23 @@
+#ifndef MRA_KERNELS_KERNEL_STATE_H
+#define MRA_KERNELS_KERNEL_STATE_H
+
+namespace mra::detail {
+
+  /**
+   * The state a kernel can be in.
+   *
+   * Typical state transitions are
+   * Initialized -> Select -> Submit -> Wait -> Epilogue
+   */
+  enum class KernelState {
+    Initialized, ///< The kernel was initialized
+    Select,      ///< select() was called on the kernel
+    Submit,      ///< The kernel was submitted
+    Wait,        ///< The operations to wait for were queried
+    Epilogue,    ///< The epilogue was called
+  };
+
+} // namespace mra::detail
+
+
+#endif // MRA_KERNELS_KERNEL_STATE_H

--- a/include/mra/tensor/functionnode.h
+++ b/include/mra/tensor/functionnode.h
@@ -4,6 +4,7 @@
 #include "mra/misc/key.h"
 #include "mra/ops/functions.h"
 #include "mra/tensor/tensor.h"
+#include "mra/misc/dims.h"
 
 #include <ttg/serialization/std/vector.h>
 #include <ttg/serialization/std/array.h>


### PR DESCRIPTION
The kernel should encapsulate what is needed during the kernel execution. The task should handle the data flow logic and only provide inputs to the kernel.
Because coroutines are stackless, we still need to orchestrate the kernel execution from the task. That logic becomes much simpler though.