### PR TITLE
Project: drop coefficients if not leaf

### DIFF
--- a/include/mra/kernels/fcoeffs.h
+++ b/include/mra/kernels/fcoeffs.h
@@ -95,6 +95,11 @@ namespace mra {
             // std::cout << "fcoeffs not leaf " << key << " norm " << norm << std::endl;
           }
         }
+        SYNCTHREADS();
+        if (!*is_leaf) {
+          /* zero out coeffs if this is not a leaf */
+          coeffs = T(0.0);
+        }
       }
     }
 

--- a/include/mra/tasks/project.h
+++ b/include/mra/tasks/project.h
@@ -145,6 +145,9 @@ namespace mra{
         }
 
         if (!result.is_all_leaf()) {
+          if (!result.is_any_leaf()) {
+            result = node_type(key, N); // drop coeffs if none of the functions are leafs
+          }
           std::vector<mra::Key<NDIM>> bcast_keys;
           for (auto child : children(key)) bcast_keys.push_back(child);
 #ifndef MRA_ENABLE_HOST

--- a/include/mra/tensor/functionnode.h
+++ b/include/mra/tensor/functionnode.h
@@ -273,6 +273,14 @@ namespace mra {
           return all_leaf;
         }
 
+        bool is_any_leaf() const {
+          bool any_leaf = false;
+          for (auto& data : m_metadata) {
+            any_leaf |= data.is_leaf;
+          }
+          return any_leaf;
+        }
+
         bool& is_leaf(size_type i) {
           return m_metadata[i].is_leaf;
         }


### PR DESCRIPTION
Zero out individual functions in the kernel and drop the whole node none of the functions are leafs. This is needed to correctly compare with MADNESS.